### PR TITLE
Replaced deprecated render with createRoot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,10 @@
  */
 
 import React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 
-render(<App></App>, document.getElementById("app"));
+const container = document.getElementById("app");
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
Hello, @alfredodeza , there was an issue with `render` after they [deprecated it with React 18](https://react.dev/reference/react-dom/render). I have had issues with it myself and it was causing my deployed page to be blank. [Issue#132](https://github.com/github-education-resources/codespaces-project-template-js/issues/132#issue-2375095841) mentioned this exact same problem and i provided an easy fix.

Actually, only `index.js` needed to be updated and after some saerching, I found the fix and wanted to create a pull request.

Original:

```js
/**
 * Entry point of application, where App is rendered within the div with the id of "app" 
 */

import React from "react";
import { render } from "react-dom";

import App from "./App";

render(<App></App>, document.getElementById("app"));

```

Fixed:

```js
/**
 * Entry point of application, where App is rendered within the div with the id of "app" 
 */

import React from "react";
import { createRoot } from "react-dom/client";

import App from "./App";

const container = document.getElementById("app");
const root = createRoot(container);
root.render(<App />);

```